### PR TITLE
Copy the url just by one click

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -313,7 +313,7 @@ async def get_config(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
             مقدار url پایین رو کپی کنید و در برنامه اضافه بکنید
             """
             await update.callback_query.message.reply_text(result)
-            result=f"{url[0]}"
+            result=f"`{url[0]}`"
             await update.callback_query.message.reply_text(result)
     else:
         result="تو قبلا از این منطقه فیلترشکن گرفتی برای اینکه ببینیش از منوی اصلی گزینه (وضعیت من چیه؟) رو انتخاب کن"
@@ -415,7 +415,7 @@ async def status(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """
     await update.callback_query.message.reply_text(text)
     for url in urls:
-        text=f"{url[0]}"
+        text=f"`{url[0]}`"
         await update.callback_query.message.reply_text(text)
 
 def main() -> None:


### PR DESCRIPTION
Enclose url in triple backquote symbols to make it monospaced: “`url`“.

By adding  backquote symbols, we can copy the url just by one click.

![image](https://user-images.githubusercontent.com/20496196/213743622-d407582f-d307-4488-a993-b8ef328c3c14.png)
